### PR TITLE
Improve parsing of blocklists by removing comments and validating IPs

### DIFF
--- a/config/abuseip.php
+++ b/config/abuseip.php
@@ -1,22 +1,23 @@
 <?php
 
+use Illuminate\Support\Facades\Cache;
+
 return [
-    
-    
+
     /*
     |--------------------------------------------------------------------------
     | ABUSE_IP Source URL
     |--------------------------------------------------------------------------
     |
-    | The source URLs yielding a list of disposable email domains. Change these
-    | to whatever source you like. Just make sure they all return a JSON array.
-    |
-    | A sensible default is provided using jsDelivr's services. jsDelivr is
-    | a free service, so there are no uptime or support guarantees.
+    | The source URLs yielding a list of abusive IPs. Change these to whatever
+    | sources you like. Just make sure they are separated by newlines.
     |
     */
     'source' => [
-        'https://raw.githubusercontent.com/borestad/blocklist-abuseipdb/master/abuseipdb-s100-all.ipv4'
+        // https://github.com/borestad/blocklist-abuseipdb
+        // Do not use the abuseipdb-s100-all.ipv4. It is only exposed for statistical usage.
+        // Recommended usage is the maximum 30 days or less to avoid false positives.
+        'https://raw.githubusercontent.com/borestad/blocklist-abuseipdb/main/abuseipdb-s100-30d.ipv4',
     ],
 
     'abuse_ips' => function () {
@@ -26,5 +27,5 @@ return [
         });
     },
 
-    'storage' => storage_path('framework/abuseip.json'),
+    'storage' => storage_path('framework/cache/abuseip.json'),
 ];

--- a/tests/Feature/UpdateAbuseIpTest.php
+++ b/tests/Feature/UpdateAbuseIpTest.php
@@ -17,10 +17,15 @@ class UpdateAbuseIpTest extends TestCase
 
     public function testUpdateAbuseIpCommand()
     {
-        Http::fake([
-            'https://raw.githubusercontent.com/borestad/blocklist-abuseipdb/master/ips.txt' => Http::response("192.168.0.1\n10.0.0.1\n", 200),
-            'https://example.com/another-ip-list.txt' => Http::response("172.16.0.1\n10.0.0.1\n127.0.0.1", 200),
+        config(['abuseip.source' => [
+            'https://raw.githubusercontent.com/borestad/blocklist-abuseipdb/main/abuseipdb-s100-all.ipv4',
+            'https://example.com/blocklist-with-comments.txt',
+        ]]);
 
+        Http::fake([
+            'https://raw.githubusercontent.com/borestad/blocklist-abuseipdb/master/ips.txt' => Http::response("192.168.0.1\n10.0.0.1\n"),
+            'https://example.com/another-ip-list.txt' => Http::response("172.16.0.1\n10.0.0.1\n127.0.0.1"),
+            'https://example.com/blocklist-with-comments.txt' => Http::response("# Some Blocklist\n1.2.3.4 # brute-force\n5.6.7.8\n127.0.0.9"),
         ]);
 
         //Run the Console command
@@ -30,11 +35,14 @@ class UpdateAbuseIpTest extends TestCase
         $this->assertStringContainsString('IP blocklist updated successfully', Artisan::output());
 
         // Assert the cache contains the correct IPS
-        $cachedIps =Cache::get('abuse_ips');
+        $cachedIps = Cache::get('abuse_ips');
         $this->assertNotEmpty($cachedIps);
         $this->assertContains('1.0.136.77', $cachedIps);
         $this->assertContains('1.0.158.159', $cachedIps);
         $this->assertContains('1.1.109.151', $cachedIps);
+        $this->assertContains('1.2.3.4', $cachedIps);
+        $this->assertContains('5.6.7.8', $cachedIps);
+        $this->assertNotContains('# Some Blocklist', $cachedIps);
 
         // Check that ip.json file is updated
         $ipjsonPath = config('abuseip.storage') ;
@@ -44,6 +52,8 @@ class UpdateAbuseIpTest extends TestCase
         $this->assertContains('1.0.136.77', $ipsfromFile);
         $this->assertContains('1.0.158.159', $ipsfromFile);
         $this->assertContains('1.1.109.151', $ipsfromFile);
-
+        $this->assertContains('1.2.3.4', $ipsfromFile);
+        $this->assertContains('5.6.7.8', $ipsfromFile);
+        $this->assertNotContains('# Some Blocklist', $ipsfromFile);
     }
 }


### PR DESCRIPTION
- Improve parsing of blocklists by removing comments (both inline and line comments) and validating IPs
- Default source URL config to the `borestad/blocklist-abuseipdb` recommended `30d` blocklist
- Import Cache facade in `abuseip.php` configuration