### PR TITLE
Configurable IP storage format

### DIFF
--- a/config/abuseip.php
+++ b/config/abuseip.php
@@ -4,7 +4,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | ABUSE_IP Source URL
+    | AbuseIP Source URL
     |--------------------------------------------------------------------------
     |
     | The source URLs yielding a list of abusive IPs. Change these to whatever
@@ -35,5 +35,21 @@ return [
         // Add more IPs here...
     ],
 
-    'storage' => storage_path('framework/cache/abuseip.json'),
+    /*
+    |--------------------------------------------------------------------------
+    | AbuseIP Storage
+    |--------------------------------------------------------------------------
+    |
+    | The path to store the abuseip.json file which is cached upon retrieval.
+    | By default using the compress option, where the IPs are stored as integers.
+    | If you prefer to keep the IPs as strings and store them in a human-readable
+    | format using JSON_PRETTY_PRINT, set the compress option to false.
+    |
+    */
+    'storage' => [
+        'path' => storage_path(
+            env('ABUSEIP_STORAGE_PATH', 'framework/cache/abuseip.json')
+        ),
+        'compress' => env('ABUSEIP_STORAGE_COMPRESS', true),
+    ],
 ];

--- a/src/AbuseIPServiceProvider.php
+++ b/src/AbuseIPServiceProvider.php
@@ -22,7 +22,7 @@ class AbuseIPServiceProvider extends ServiceProvider
         ], 'laravel-abuse-ip');
 
         $this->publishes([
-            __DIR__ . '/../abuseip.json' => config('abuseip.storage'),
+            __DIR__ . '/../abuseip.json' => config('abuseip.storage.path'),
         ], 'laravel-abuse-ip');
 
         if ($this->app->runningInConsole()) {

--- a/src/Console/Commands/UpdateAbuseIps.php
+++ b/src/Console/Commands/UpdateAbuseIps.php
@@ -27,10 +27,15 @@ class UpdateAbuseIps extends Command
         }
 
         // convert ips to integers
-        $ips = array_map(fn(string $ip) => ip2long($ip), $ips);
+        if (config('abuseip.storage.compress')) {
+            $ips = array_map(fn(string $ip) => ip2long($ip), $ips);
+        }
 
         // save to abuseip.json
-        file_put_contents(config('abuseip.storage'), json_encode($ips));
+        file_put_contents(
+            config('abuseip.storage.path'),
+            json_encode($ips, config('abuseip.storage.compress') ? 0 : JSON_PRETTY_PRINT)
+        );
 
         try {
             Cache::forever('abuse_ips', $ips);

--- a/src/Middleware/AbuseIp.php
+++ b/src/Middleware/AbuseIp.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RahulAlam31\Middleware;
+namespace RahulAlam31\LaravelAbuseIp\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;

--- a/src/Middleware/AbuseIp.php
+++ b/src/Middleware/AbuseIp.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Request;
 
 class AbuseIp
 {
-    protected $whitelistedIPs;
+    protected array $whitelistedIPs;
 
     public function __construct()
     {
@@ -17,16 +17,16 @@ class AbuseIp
 
     public function handle(Request $request, Closure $next)
     {
+        $ip = $request->ip();
 
         // Check if the IP is whitelisted
-        if (in_array($request->ip(), $this->whitelistedIPs)) {
+        if (in_array($ip, $this->whitelistedIPs)) {
             return $next($request); // Allow request if IP is whitelisted
         }
 
-        if (is_abused_ip($request->ip())) {
-
-            // Log::info('Blocking IP: ' . $request->ip());
-            return response('Your IP address has been blocked', 403);
+        if (is_abused_ip($ip)) {
+            // Log::info('Blocking IP: ' . $ip);
+            abort(403, 'Your IP address has been blocked');
         }
 
         return $next($request);

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -6,7 +6,7 @@ if (! function_exists('abuse_ips')) {
     function abuse_ips(): array
     {
         return Cache::get('abuse_ips', function () {
-            $path = config('abuseip.storage');
+            $path = config('abuseip.storage.path');
 
             return file_exists($path) ? json_decode(file_get_contents($path), true) : [];
         });
@@ -16,7 +16,7 @@ if (! function_exists('abuse_ips')) {
 if (! function_exists('is_abused_ip')) {
     function is_abused_ip(string|int $ip): bool
     {
-        if (is_string($ip)) {
+        if (is_string($ip) && config('abuseip.storage.compress')) {
             $ip = is_numeric($ip) ? (int) $ip : ip2long($ip);
         }
 

--- a/tests/Feature/BlockIPTest.php
+++ b/tests/Feature/BlockIPTest.php
@@ -2,12 +2,11 @@
 
 namespace RahulAlam31\LaravelAbuseIp\tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Orchestra\Testbench\TestCase;
 use RahulAlam31\LaravelAbuseIp\AbuseIPServiceProvider;
+use RahulAlam31\LaravelAbuseIp\Middleware\AbuseIp;
 use Illuminate\Support\Facades\Route;
-use App\Http\Middleware\AbuseIp;
 
 class BlockIPTest extends TestCase
 {
@@ -34,9 +33,8 @@ class BlockIPTest extends TestCase
 
     public function testRequestFromBlockedIp()
     {
-
         // Add test IPs to the cache
-        // Cache::forever('abuse_ips', ['192.168.0.1', '10.0.0.1']);
+        Cache::forever('abuse_ips', [ip2long('1.0.136.77')]);
 
         // Simulate request from a blocked IP
         $response = $this->withServerVariables(['REMOTE_ADDR' => '1.0.136.77'])->get('/test-route');
@@ -47,7 +45,7 @@ class BlockIPTest extends TestCase
     public function testRequestFromAllowedIp()
     {
         // Add test IPs to the cache
-        Cache::forever('abuse_ips', ['192.168.0.1', '10.0.0.1']);
+        Cache::forever('abuse_ips', [ip2long('192.168.0.1'), ip2long('10.0.0.1')]);
 
         // Simulate request from a non-blocked IP
         $response = $this->withServerVariables(['REMOTE_ADDR' => '8.8.8.8'])->get('/test-route');

--- a/tests/Feature/UpdateAbuseIpTest.php
+++ b/tests/Feature/UpdateAbuseIpTest.php
@@ -17,10 +17,13 @@ class UpdateAbuseIpTest extends TestCase
 
     public function testUpdateAbuseIpCommand()
     {
-        config(['abuseip.source' => [
-            'https://raw.githubusercontent.com/borestad/blocklist-abuseipdb/main/abuseipdb-s100-all.ipv4',
-            'https://example.com/blocklist-with-comments.txt',
-        ]]);
+        config([
+            'abuseip.source' => [
+                'https://raw.githubusercontent.com/borestad/blocklist-abuseipdb/main/abuseipdb-s100-all.ipv4',
+                'https://example.com/blocklist-with-comments.txt',
+            ],
+            'abuseip.storage.compress' => false,
+        ]);
 
         Http::fake([
             'https://raw.githubusercontent.com/borestad/blocklist-abuseipdb/master/ips.txt' => Http::response("192.168.0.1\n10.0.0.1\n"),
@@ -45,7 +48,7 @@ class UpdateAbuseIpTest extends TestCase
         $this->assertNotContains('# Some Blocklist', $cachedIps);
 
         // Check that ip.json file is updated
-        $ipjsonPath = config('abuseip.storage') ;
+        $ipjsonPath = config('abuseip.storage.path') ;
         $this->assertFileExists($ipjsonPath);
         $ipsfromFile = json_decode(file_get_contents($ipjsonPath), true);
         $this->assertNotEmpty($ipsfromFile);


### PR DESCRIPTION
The #8 proposed storage format of IPs as integers (using [`ip2long()`](https://www.php.net/ip2long)) was integrated in [v1.3](https://github.com/rahulalam31/Laravel-Abuse-IP/releases/tag/1.3). There were some nice additions and it also fixed the `abuseip.php` config from getting cached (e.g. with `php artisan optimize`). But I didn't quite like how the new storage format "obfuscates" the IPs for a (possibly) minimal speed/storage space improvement. I prefer storing the IPs as plain strings in a pretty printed JSON, as it was before. Like this, we can easily `grep` for any abusive IP without knowing anything about the logic of this package.

So why not just make it optional? That's the aim of this PR with the added `abuseip.storage.compress` config option, even though tests should be improved to cover both config options.